### PR TITLE
fix: add subject info to score/evaluation api #163

### DIFF
--- a/fastapi/app/api/v1/score.py
+++ b/fastapi/app/api/v1/score.py
@@ -52,7 +52,15 @@ class ScoreAPI:
                 Score.evaluation_uuid == evaluation_uuid,
             )
         )
+        attend_subject = AttendSubjectCRUD(
+            request.state.db_session
+        ).get_by_user_and_subject(request.user, evaluation.subject)
+        if attend_subject is None:
+            raise ApiException(NotFoundObjectMatchingUuid(AttendSubject))
         return {
+            "attend_subject_uuid": attend_subject.uuid,
+            "subject_name": attend_subject.subject.name,
+            "subject_uuid": attend_subject.subject.uuid,
             "evaluation_name": evaluation.name,
             "evaluation_uuid": evaluation.uuid,
             "rate": evaluation.rate,


### PR DESCRIPTION
# Overview <!-- What is the change -->
```json
{
  "attend_subject_uuid": "f2daaaa8-3127-4ef9-8e05-06b227b41f5b",
  "subject_name": "コンピュータリテラシ",
  "subject_uuid": "767ca2c1-744a-4a04-a6aa-4cd0ef4c77cc",
  "evaluation_name": "合計",
  "evaluation_uuid": "fc5272c6-60cf-482f-b7af-10d12748c4ca",
  "rate": 100,
  "scores": [
    {
      "got_score": 42,
      "max_score": 50,
      "score_uuid": "b941fc1d-b6ba-4fed-b1bc-e13bb6e1a58d",
      "memo": null
    }
  ]
}
```

# Issue number <!-- e.g. Close #123, Fix #456 -->
Close #163 


# How to check the revision


# Points for Review <!-- Things you want reviewers to check, etc. -->


# Remarks <!-- Any other comments -->


<!-- You don't have to fill in all the blanks, but write the necessary information clearly. -->