### PR TITLE
fix: add teacher info in attend subject readable api #184

### DIFF
--- a/fastapi/app/api/v1/attend_subject.py
+++ b/fastapi/app/api/v1/attend_subject.py
@@ -66,6 +66,8 @@ class AttendSubjectAPI:
                     "target_score": attend_subject.target_score,
                     "subject_uuid": attend_subject.subject_uuid,
                     "subject_name": attend_subject.subject.name,
+                    "teacher_uuid": attend_subject.subject.teacher.uuid,
+                    "teacher_name": attend_subject.subject.teacher.name,
                     "evaluations": evaluations_data,
                 }
             )
@@ -117,6 +119,8 @@ class AttendSubjectAPI:
             "target_score": attend_subject.target_score,
             "subject_uuid": attend_subject.subject_uuid,
             "subject_name": attend_subject.subject.name,
+            "teacher_uuid": attend_subject.subject.teacher.uuid,
+            "teacher_name": attend_subject.subject.teacher.name,
             "evaluations": evaluations_data,
         }
 


### PR DESCRIPTION
# Overview <!-- What is the change -->
attend_subjectでteacherも返す(readableのみ)

# Issue number <!-- e.g. Close #123, Fix #456 -->
Close #184 


# How to check the revision
use swagger and check attend_subject api

# Points for Review <!-- Things you want reviewers to check, etc. -->


# Remarks <!-- Any other comments -->
only readable

<!-- You don't have to fill in all the blanks, but write the necessary information clearly. -->