### PR TITLE
開講科目一覧をとるクエリを変更

### DIFF
--- a/frontend/src/components/AddSubject.tsx
+++ b/frontend/src/components/AddSubject.tsx
@@ -14,16 +14,10 @@ import {
   Select,
   ModalFooter,
 } from '@chakra-ui/react';
-import SubjectList, { SubjectListProps } from './SubjectList';
 import { Dispatch, SetStateAction } from 'react';
-import { SelectProps } from '@chakra-ui/react';
 import { GRADELIST } from '../pages/edit';
 import { SubjectInterface } from 'repositories';
-import {
-  AttendSubjectReadableRepository,
-  AttendSubjectReadableInterface,
-} from 'repositories/AttendSubjectReadableRepository';
-import { useState, useEffect } from 'react';
+import { AttendSubjectReadableRepository } from 'repositories/AttendSubjectReadableRepository';
 
 export type AddSubjectProps = {
   gotlist: SubjectInterface[][];

--- a/frontend/src/components/DeleteSubject.tsx
+++ b/frontend/src/components/DeleteSubject.tsx
@@ -8,12 +8,8 @@ import {
   AlertDialogOverlay,
 } from '@chakra-ui/react';
 import { DeleteIcon } from '@chakra-ui/icons';
-import { Button, Flex } from '@chakra-ui/react';
-import { SubjectListProps } from './SubjectList';
-import { Dispatch, SetStateAction } from 'react';
-import { AttendSubjectReadableInterface } from 'repositories/AttendSubjectReadableRepository';
+import { Button } from '@chakra-ui/react';
 import { AttendSubjectReadableRepository } from 'repositories/AttendSubjectReadableRepository';
-import { useState, useEffect } from 'react';
 
 export type DeleteSubjectProp = {
   uuid: string;

--- a/frontend/src/components/EditButton.tsx
+++ b/frontend/src/components/EditButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, Text, IconButton } from '@chakra-ui/react';
+import { Link, IconButton } from '@chakra-ui/react';
 import { EditIcon } from '@chakra-ui/icons';
 
 const EditButton: React.FC = () => {

--- a/frontend/src/components/SubjectList.tsx
+++ b/frontend/src/components/SubjectList.tsx
@@ -6,23 +6,10 @@ import {
   Stack,
   Text,
   Circle,
-  VStack,
   Spacer,
 } from '@chakra-ui/layout';
-import {
-  ArrowForwardIcon,
-  AddIcon,
-  DeleteIcon,
-  CloseIcon,
-} from '@chakra-ui/icons';
-import DeleteSubject from './DeleteSubject';
-import { Evaluation } from 'domains';
-import {
-  AttendSubjectReadable,
-  EvaluationReadable,
-} from 'domains/AttendSubjectReadable';
+import { ArrowForwardIcon } from '@chakra-ui/icons';
 import { AttendSubjectReadableInterface } from 'repositories/AttendSubjectReadableRepository';
-import { Evaluations } from 'repositories/AttendSubjectReadableRepository';
 
 export type SubjectListProps = {
   subject: AttendSubjectReadableInterface;

--- a/frontend/src/components/SubjectNameList.tsx
+++ b/frontend/src/components/SubjectNameList.tsx
@@ -1,17 +1,6 @@
 import React from 'react';
-import {
-  Divider,
-  Stack,
-  HStack,
-  Circle,
-  Text,
-  Spacer,
-  Link,
-} from '@chakra-ui/react';
-import { useState, SetStateAction, Dispatch } from 'react';
+import { Divider, Stack, HStack, Text, Spacer } from '@chakra-ui/react';
 import DeleteSubject from './DeleteSubject';
-import { SubjectListProps } from './SubjectList';
-import { AttendSubjectReadableInterface } from 'repositories/AttendSubjectReadableRepository';
 
 export type SubjectNameListProps = {
   subjectName: string;

--- a/frontend/src/pages/edit/index.tsx
+++ b/frontend/src/pages/edit/index.tsx
@@ -52,7 +52,7 @@ const Edit = () => {
         semester = '後期';
       }
       const termRepo = await TermRepository.gets(year, semester);
-      if (termRepo === undefined) {
+      if (termRepo === undefined || termRepo!.length === 0) {
         throw new Error('Cannot get term infomation!');
       }
       //setTerm(termRepo);
@@ -60,16 +60,16 @@ const Edit = () => {
       // 学年毎の開講科目の取得
       const category = ['一般', '専門'];
       const subjectRepos: SubjectInterface[][] = [];
-      let oneGradeSubjectRepo: SubjectInterface[] = [];
       for (let i = 1; i <= 5; i++) {
-        for (let j = 1; j < 2; j++) {
+        let oneGradeSubjectRepo: SubjectInterface[] = [];
+        for (let j = 0; j < 2; j++) {
           const tempSubjectRepo = await SubjectRepository.gets(
             userRepo.school.uuid,
             userRepo.department.uuid,
+            termRepo[0].uuid,
             category[j],
             i,
           );
-          //const pretempSubjectRepo = tempSubjectRepo;
           if (tempSubjectRepo === undefined || tempSubjectRepo === null) {
             throw new Error('Cannot get subjects');
           }
@@ -77,7 +77,7 @@ const Edit = () => {
         }
         subjectRepos.push(oneGradeSubjectRepo);
       }
-      if (subjectRepos === undefined) {
+      if (subjectRepos === undefined || subjectRepos!.length === 0) {
         throw new Error('Cannot get subjects information!');
       }
       setAllSubject(subjectRepos);
@@ -112,7 +112,7 @@ const Edit = () => {
   const getAttendSubject = async () => {
     try {
       const attendSubjectRepo = await AttendSubjectReadableRepository.gets();
-      if (attendSubjectRepo === undefined) {
+      if (attendSubjectRepo === undefined || attendSubjectRepo.length === 0) {
         throw new Error('Cannot get attend subject infomation!');
       }
       setSubject(attendSubjectRepo);
@@ -137,7 +137,7 @@ const Edit = () => {
   >([]);
 
   const addAllSubject = () => {
-    for (const s of allSubject[userInfo!.grade - 1]) {
+    for (const s of allSubject[userInfo!.grade]) {
       const subjectRepo = AttendSubjectReadableRepository.create({
         target_value: defaultTargetValue,
         target_score: defaultTargetScore,

--- a/frontend/src/pages/edit/index.tsx
+++ b/frontend/src/pages/edit/index.tsx
@@ -4,17 +4,12 @@ import {
   Divider,
   Heading,
   Center,
-  Flex,
   Button,
-  Spacer,
-  Link,
   Text,
 } from '@chakra-ui/react';
 import SubjectNameList from '../../components/SubjectNameList';
-import { useRef, useState, useEffect } from 'react';
-import { AddIcon } from '@chakra-ui/icons';
+import { useState, useEffect } from 'react';
 import AddSubject from '../../components/AddSubject';
-import { SubjectListProps } from '../../components/SubjectList';
 import {
   AttendSubjectReadableRepository,
   AttendSubjectReadableInterface,
@@ -25,13 +20,11 @@ import {
   SubjectRepository,
   SubjectInterface,
   TermRepository,
-  TermInterface,
 } from 'repositories';
 import {
   defaultTargetValue,
   defaultTargetScore,
 } from '../../components/AddSubject';
-import { Dispatch } from 'react';
 
 export const GRADELIST = [1, 2, 3, 4, 5];
 
@@ -62,21 +55,27 @@ const Edit = () => {
       if (termRepo === undefined) {
         throw new Error('Cannot get term infomation!');
       }
-      setTerm(termRepo);
+      //setTerm(termRepo);
 
       // 学年毎の開講科目の取得
+      const category = ['一般', '専門'];
       const subjectRepos: SubjectInterface[][] = [];
+      let oneGradeSubjectRepo: SubjectInterface[] = [];
       for (let i = 1; i <= 5; i++) {
-        const subjectRepo = await SubjectRepository.gets(
-          userRepo.school.uuid,
-          userRepo.department.uuid,
-          termRepo[0].uuid,
-          i,
-        );
-        if (subjectRepo === undefined) {
-          throw new Error('Cannot get subject infomation!');
+        for (let j = 1; j < 2; j++) {
+          const tempSubjectRepo = await SubjectRepository.gets(
+            userRepo.school.uuid,
+            userRepo.department.uuid,
+            category[j],
+            i,
+          );
+          //const pretempSubjectRepo = tempSubjectRepo;
+          if (tempSubjectRepo === undefined || tempSubjectRepo === null) {
+            throw new Error('Cannot get subjects');
+          }
+          oneGradeSubjectRepo = oneGradeSubjectRepo.concat(tempSubjectRepo!);
         }
-        subjectRepos.push(subjectRepo);
+        subjectRepos.push(oneGradeSubjectRepo);
       }
       if (subjectRepos === undefined) {
         throw new Error('Cannot get subjects information!');
@@ -129,7 +128,7 @@ const Edit = () => {
   }, [isUpdating]);
 
   const [userInfo, setUser] = useState<UserInterface>();
-  const [currentTerm, setTerm] = useState<TermInterface[]>([]);
+  //const [currentTerm, setTerm] = useState<TermInterface[]>([]);
   const [allSubject, setAllSubject] = useState<SubjectInterface[][]>([]);
   const [errMsg, setErr] = useState<string>('');
 

--- a/frontend/src/pages/edit/index.tsx
+++ b/frontend/src/pages/edit/index.tsx
@@ -43,7 +43,7 @@ const Edit = () => {
 
       // term の取得
       const today = new Date();
-      let year = today.getFullYear();
+      let year = today.getFullYear() + 1;
       const month = today.getMonth();
       let semester;
       if (4 <= month && month <= 9) {

--- a/frontend/src/pages/edit/index.tsx
+++ b/frontend/src/pages/edit/index.tsx
@@ -43,13 +43,17 @@ const Edit = () => {
 
       // term の取得
       const today = new Date();
-      const year = today.getFullYear();
+      let year = today.getFullYear();
       const month = today.getMonth();
       let semester;
       if (4 <= month && month <= 9) {
         semester = '前期';
       } else {
         semester = '後期';
+      }
+      if (semester === '後期' && 1 <= month) {
+        // year を年度にする
+        year--;
       }
       const termRepo = await TermRepository.gets(year, semester);
       if (termRepo === undefined || termRepo!.length === 0) {

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -28,6 +28,7 @@ const Home = () => {
         setSubjects(lis);
       })
       .catch(err => {
+        console.log(err);
         setSubjects([]);
       });
   }, []);

--- a/frontend/src/repositories/SubjectRepository.ts
+++ b/frontend/src/repositories/SubjectRepository.ts
@@ -41,18 +41,23 @@ export class SubjectRepository {
   static async gets(
     school: string,
     department: string,
+    term: string,
     category: string,
     grade: number,
   ) {
     const authClientObject = authClient();
     if (!authClientObject) return;
-    const department2 = '471bfab6-e473-491b-b55e-08f461079b29';
-    const department3 = 'bc7f927c-215b-46fe-b777-4f53c3d13c8b';
-    const res = await authClientObject.get<SubjectInterface[]>(
-      //`/api/v1/subjects/?school_uuid=${school}&department_uuid=${department}&term_uuid${term}&target_grade=${grade}`,
-      `/api/v1/subjects/?school_uuid=${school}&category${category}&target_grade=${grade}`,
-    );
-    return res.data;
+    if (category === '一般') {
+      const res = await authClientObject.get<SubjectInterface[]>(
+        `/api/v1/subjects/?school_uuid=${school}&term_uuid=${term}&category=${category}&target_grade=${grade}`,
+      );
+      return res.data;
+    } else if (category === '専門') {
+      const res = await authClientObject.get<SubjectInterface[]>(
+        `/api/v1/subjects/?school_uuid=${school}&department_uuid=${department}&term_uuid=${term}&category=${category}&target_grade=${grade}`,
+      );
+      return res.data;
+    }
   }
   static async get(uuid: string) {
     const authClientObject = authClient();

--- a/frontend/src/repositories/SubjectRepository.ts
+++ b/frontend/src/repositories/SubjectRepository.ts
@@ -41,7 +41,7 @@ export class SubjectRepository {
   static async gets(
     school: string,
     department: string,
-    term: string,
+    category: string,
     grade: number,
   ) {
     const authClientObject = authClient();
@@ -50,7 +50,7 @@ export class SubjectRepository {
     const department3 = 'bc7f927c-215b-46fe-b777-4f53c3d13c8b';
     const res = await authClientObject.get<SubjectInterface[]>(
       //`/api/v1/subjects/?school_uuid=${school}&department_uuid=${department}&term_uuid${term}&target_grade=${grade}`,
-      `/api/v1/subjects/?school_uuid=${school}&term_uuid${term}&target_grade=${grade}`,
+      `/api/v1/subjects/?school_uuid=${school}&category${category}&target_grade=${grade}`,
     );
     return res.data;
   }


### PR DESCRIPTION
# Overview <!-- What is the change -->
履修科目を追加するモーダルで叩いている API のクエリを正しく変更。
- 学校、学科、学年、学期で絞る
- 一般科目と専門科目を取得

# Issue number <!-- e.g. Close #123, Fix #456 -->


# How to check the revision
- 学年毎に正しい開講科目が取得されるか

# Points for Review <!-- Things you want reviewers to check, etc. -->


# Remarks <!-- Any other comments -->

<!-- You don't have to fill in all the blanks, but write the necessary information clearly. -->